### PR TITLE
feat: Add first and last page pagination buttons

### DIFF
--- a/public/passengers.html
+++ b/public/passengers.html
@@ -45,12 +45,18 @@
         </div>
 
         <div id="pagination-controls" class="flex justify-center items-center mt-8">
-            <button id="prev-page" class="bg-accent hover:bg-tertiary text-light font-bold py-2 px-4 rounded-l">
+            <button id="first-page" class="bg-accent hover:bg-tertiary text-light font-bold py-2 px-4 rounded-l">
+                Anar al principi
+            </button>
+            <button id="prev-page" class="bg-accent hover:bg-tertiary text-light font-bold py-2 px-4">
                 Anterior
             </button>
             <span id="page-info" class="px-4 py-2 bg-secondary text-light"></span>
-            <button id="next-page" class="bg-accent hover:bg-tertiary text-light font-bold py-2 px-4 rounded-r">
+            <button id="next-page" class="bg-accent hover:bg-tertiary text-light font-bold py-2 px-4">
                 Següent
+            </button>
+            <button id="last-page" class="bg-accent hover:bg-tertiary text-light font-bold py-2 px-4 rounded-r">
+                Anar al final
             </button>
         </div>
     </div>

--- a/public/passengers.js
+++ b/public/passengers.js
@@ -1,12 +1,15 @@
 document.addEventListener('DOMContentLoaded', () => {
     const passengersContainer = document.getElementById('passengers-container');
     const addPassengerForm = document.getElementById('add-passenger-form');
+    const firstPageButton = document.getElementById('first-page');
     const prevPageButton = document.getElementById('prev-page');
     const nextPageButton = document.getElementById('next-page');
+    const lastPageButton = document.getElementById('last-page');
     const pageInfo = document.getElementById('page-info');
 
     const API_URL = 'http://localhost:3000/api/persones';
     let currentPage = 1;
+    let totalPages = 1;
     const limit = 20;
 
     const fetchPassengers = async (page) => {
@@ -37,12 +40,21 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const updatePaginationControls = (total, page, limit) => {
-        const totalPages = Math.ceil(total / limit);
+        totalPages = Math.ceil(total / limit);
         pageInfo.textContent = `Pàgina ${page} de ${totalPages}`;
 
+        firstPageButton.disabled = page <= 1;
         prevPageButton.disabled = page <= 1;
         nextPageButton.disabled = page >= totalPages;
+        lastPageButton.disabled = page >= totalPages;
     };
+
+    firstPageButton.addEventListener('click', () => {
+        if (currentPage > 1) {
+            currentPage = 1;
+            fetchPassengers(currentPage);
+        }
+    });
 
     prevPageButton.addEventListener('click', () => {
         if (currentPage > 1) {
@@ -52,8 +64,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     nextPageButton.addEventListener('click', () => {
-        currentPage++;
-        fetchPassengers(currentPage);
+        if (currentPage < totalPages) {
+            currentPage++;
+            fetchPassengers(currentPage);
+        }
+    });
+
+    lastPageButton.addEventListener('click', () => {
+        if (currentPage < totalPages) {
+            currentPage = totalPages;
+            fetchPassengers(currentPage);
+        }
     });
 
     addPassengerForm.addEventListener('submit', async (event) => {


### PR DESCRIPTION
Adds "go to beginning" and "go to end" buttons to the pagination controls on the passengers page.

- Modifies `public/passengers.html` to include the new buttons with IDs `first-page` and `last-page`.
- Updates `public/passengers.js` to handle the logic for these new buttons, including:
  - Adding event listeners to navigate to the first and last pages.
  - Disabling the buttons when on the first or last page.